### PR TITLE
Fixed typo in 'nzimm' field of CSRR*I instructions

### DIFF
--- a/src/instr-table.tex
+++ b/src/instr-table.tex
@@ -721,7 +721,7 @@
 
 &
 \multicolumn{6}{|c|}{csr} &
-\multicolumn{1}{c|}{zimm} &
+\multicolumn{1}{c|}{nzimm} &
 \multicolumn{1}{c|}{101} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRWI \\
@@ -730,7 +730,7 @@
 
 &
 \multicolumn{6}{|c|}{csr} &
-\multicolumn{1}{c|}{zimm} &
+\multicolumn{1}{c|}{nzimm} &
 \multicolumn{1}{c|}{110} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRSI \\
@@ -739,7 +739,7 @@
 
 &
 \multicolumn{6}{|c|}{csr} &
-\multicolumn{1}{c|}{zimm} &
+\multicolumn{1}{c|}{nzimm} &
 \multicolumn{1}{c|}{111} &
 \multicolumn{1}{c|}{rd} &
 \multicolumn{1}{c|}{1110011} & CSRRCI \\


### PR DESCRIPTION
In the RV64GC instruction set listings the immediate field of the CSRRWI, CSRRSI and CSRRCI instructions was called `zimm`, there was a missing `n` there - enforcing all-zero immediates wouldn't have made any sense... 🙃 